### PR TITLE
Change all examples to use /bin/bash.

### DIFF
--- a/R/advanced/R_analysis.submit
+++ b/R/advanced/R_analysis.submit
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #SBATCH --nodes=1
 #SBATCH --mem=16gb
 #SBATCH --time=10:00:00

--- a/R/advanced/get_data.submit
+++ b/R/advanced/get_data.submit
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=4
 #SBATCH --mem=5gb

--- a/abaqus/2019/abaqus.submit
+++ b/abaqus/2019/abaqus.submit
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #SBATCH --nodes=-4 # Use at most 4 nodes due to such a small problem size. Remove this as needed for larger problems.
 #SBATCH --ntasks=16
 #SBATCH --mincpus=2            # Need at least 2 CPUs (cores) per node for Abaqus to run in MPI mode

--- a/abaqus/6.14.2/abaqus.submit
+++ b/abaqus/6.14.2/abaqus.submit
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #SBATCH --nodes=-4 # Use at most 4 nodes due to such a small problem size. Remove this as needed for larger problems.
 #SBATCH --ntasks=16
 #SBATCH --mincpus=2            # Need at least 2 CPUs (cores) per node for Abaqus to run in MPI mode

--- a/blast/blast_aa_multi.submit
+++ b/blast/blast_aa_multi.submit
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=2
 #SBATCH --mem=5gb

--- a/blast/blast_nt_multi.submit
+++ b/blast/blast_nt_multi.submit
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=2
 #SBATCH --mem=5gb

--- a/blast/blast_nt_single.submit
+++ b/blast/blast_nt_single.submit
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=1
 #SBATCH --mem=5gb

--- a/blast/nucleotide/blast_nucleotide.submit
+++ b/blast/nucleotide/blast_nucleotide.submit
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=1
 #SBATCH --mem=1gb

--- a/blast/protein/blast_protein.submit
+++ b/blast/protein/blast_protein.submit
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=1
 #SBATCH --mem=1gb

--- a/gaussian/09/run-g09-general.slurm
+++ b/gaussian/09/run-g09-general.slurm
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #SBATCH -J g09
 #SBATCH --nodes=1 --ntasks-per-node=4
 #SBATCH --mem-per-cpu=2000

--- a/gaussian/16/run-g16-general.slurm
+++ b/gaussian/16/run-g16-general.slurm
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #SBATCH -J g16
 #SBATCH --nodes=1 --ntasks-per-node=4
 #SBATCH --mem-per-cpu=2000

--- a/jupyter/get_data.submit
+++ b/jupyter/get_data.submit
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=8
 #SBATCH --mem=5gb

--- a/matlab/other_examples/matlab_parallel.submit
+++ b/matlab/other_examples/matlab_parallel.submit
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=5
 #SBATCH --mem-per-cpu=1024

--- a/matlab/other_examples/matlab_serial.submit
+++ b/matlab/other_examples/matlab_serial.submit
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #SBATCH --nodes=1
 #SBATCH --mem=5gb
 #SBATCH --time=00:10:00

--- a/python/python.submit
+++ b/python/python.submit
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=1
 #SBATCH --mem=5gb

--- a/sas/sas.submit
+++ b/sas/sas.submit
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=1
 #SBATCH --mem=1gb

--- a/turbowave/turbowave.submit
+++ b/turbowave/turbowave.submit
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #SBATCH --ntasks=16
 #SBATCH --mem-per-cpu=2gb
 #SBATCH --time=06:00:00


### PR DESCRIPTION
Using /bin/sh can result in the module function being undefined
when the user's shell is tcsh.  Using /bin/bash instead fixes
the issue.